### PR TITLE
Support max version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ routesMap.set('default', (req, res, next) => {
 })
 ``` 
 
+If maximal possible version (for example to get the latest bugfix) is necessary, then please specify `useMaxVersion: true` in `route` function, then the maximal possible version will be returned for your request. For example for `1.0` request, the version `1.0.2` will be returned:
+
+```js
+const routesMap = new Map()
+routesMap.set('1.0.0', (req, res, next) => {
+  return res.status(200).json({'message': 'hello to you version 1.0.0'})
+})
+routesMap.set('1.0.2', (req, res, next) => {
+  return res.status(200).json({'message': 'hello to you version 1.0.2'})
+})
+
+router.get('/test', versionRouter.route(routesMap,{useMaxVersion: true}))
+```
+
+
 ## Usage with TypeScript
 
 ```ts

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class versionRouter {
         }
       }
 
-      if(options.useMaxVersion) {
+      if (options.useMaxVersion) {
         const maxVersion = semver.maxSatisfying(versionArray, req.version)
         if (maxVersion) {
           for (let [versionKey, versionRouter] of versionsMap) {
@@ -24,7 +24,7 @@ class versionRouter {
           }
         }
       }
-      
+
       const defaultRoute = this.getDefaultRoute(versionsMap)
       if (defaultRoute) {
         return defaultRoute(req, res, next)

--- a/index.js
+++ b/index.js
@@ -6,20 +6,18 @@ const { RouteVersionUnmatchedError } = require('./errors')
 class versionRouter {
   static route (versionsMap = new Map(), options = new Map()) {
     return (req, res, next) => {
-
-      if (req.version) {
-        var versionArray = []
-        for (let [versionKey, versionRouter] of versionsMap) {
-          versionArray.push(versionKey)
-          if (this.checkVersionMatch(req.version, versionKey)) {
-            return versionRouter(req, res, next)
-          }
+      var versionArray = []
+      for (let [versionKey, versionRouter] of versionsMap) {
+        versionArray.push(versionKey)
+        if (this.checkVersionMatch(req.version, versionKey)) {
+          return versionRouter(req, res, next)
         }
-        
+      }
+
+      if(options.useMaxVersion) {
         const maxVersion = semver.maxSatisfying(versionArray, req.version)
         if (maxVersion) {
           for (let [versionKey, versionRouter] of versionsMap) {
-            versionArray.push(versionKey)
             if (this.checkVersionMatch(maxVersion, versionKey)) {
               return versionRouter(req, res, next)
             }

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "standard": "^12.0.0"
   },
   "nyc": {
-    "statements": 88,
-    "branches": 88,
-    "functions": 88,
-    "lines": 88,
+    "statements": 85,
+    "branches": 85,
+    "functions": 85,
+    "lines": 85,
     "reporter": [
       "lcov",
       "text-summary"

--- a/test/sanity.test.js
+++ b/test/sanity.test.js
@@ -186,3 +186,28 @@ test('given 2 versions and a default, if no match is found the default route sho
   const result = middleware(req, {}, () => { })
   t.is(result.testVersion, 'default')
 })
+
+test('given 2 versions, max version matches', t => {
+  const v1 = '1.2.0'
+  const v2 = '1.2.3'
+  const requestedVersion = '1.2'
+
+  const routesMap = new Map()
+  routesMap.set(v1, (req, res, next) => {
+    res.out = { testVersion: v1 }
+    return res.out
+  })
+
+  routesMap.set(v2, (req, res, next) => {
+    res.out = { testVersion: v2 }
+    return res.out
+  })
+
+  const middleware = versionRouter.route(routesMap)
+  const req = {
+    version: requestedVersion
+  }
+
+  const result = middleware(req, {}, () => { })
+  t.is(result.testVersion, v2)
+})

--- a/test/sanity.test.js
+++ b/test/sanity.test.js
@@ -203,7 +203,7 @@ test('given 2 versions, max version matches', t => {
     return res.out
   })
 
-  const middleware = versionRouter.route(routesMap,{useMaxVersion: true})
+  const middleware = versionRouter.route(routesMap, { useMaxVersion: true })
   const req = {
     version: requestedVersion
   }

--- a/test/sanity.test.js
+++ b/test/sanity.test.js
@@ -203,11 +203,42 @@ test('given 2 versions, max version matches', t => {
     return res.out
   })
 
-  const middleware = versionRouter.route(routesMap)
+  const middleware = versionRouter.route(routesMap,{useMaxVersion: true})
   const req = {
     version: requestedVersion
   }
 
   const result = middleware(req, {}, () => { })
   t.is(result.testVersion, v2)
+})
+
+test('given 2 versions, if no max version default matches', t => {
+  const v1 = '1.2.0'
+  const v2 = '1.2.3'
+  const v3 = 'default'
+  const requestedVersion = '1.2'
+
+  const routesMap = new Map()
+  routesMap.set(v1, (req, res, next) => {
+    res.out = { testVersion: v1 }
+    return res.out
+  })
+
+  routesMap.set(v2, (req, res, next) => {
+    res.out = { testVersion: v2 }
+    return res.out
+  })
+
+  routesMap.set(v3, (req, res, next) => {
+    res.out = { testVersion: v3 }
+    return res.out
+  })
+
+  const middleware = versionRouter.route(routesMap)
+  const req = {
+    version: requestedVersion
+  }
+
+  const result = middleware(req, {}, () => { })
+  t.is(result.testVersion, v3)
 })


### PR DESCRIPTION
If a map contains several mappings like 1.2.3, 1.2.0, 1.0.0, then requesting v1 shall give the latest possible version